### PR TITLE
Speeding up +=  operation of LpAffineExpression

### DIFF
--- a/src/pulp/pulp.py
+++ b/src/pulp/pulp.py
@@ -749,11 +749,17 @@ class LpAffineExpression(_DICT_TYPE):
     def __radd__(self, other):
         return self.copy().addInPlace(other)
 
+    def __iadd__(self, other):
+        return self.addInPlace(other)
+
     def __sub__(self, other):
         return self.copy().subInPlace(other)
 
     def __rsub__(self, other):
         return (-self).addInPlace(other)
+
+    def __isub__(self, other):
+        return self.subInPlace(other)
 
     def __mul__(self, other):
         e = self.emptyCopy()


### PR DESCRIPTION
The previous += operation of LpAffineExpression is extremely slow when you have a large quantity of elements inside an LpAffineExpression. This is because the __add__() function was used (and it makes an expensive copy of itself each time a new element was added!). If the += is in a for loop for adding one element each time, it is exponential worst. 

This update implements an __iadd__() function for LpAffineExpression, that avoid copying LpAffineExpression each time new elements are added. Now we can keep the pulp "magic" without performance issue when constructing a big expression (same performance as lpsum() function). For example the following code was previously prohibitive:

    vars = LpVariable.dicts("var",range(1000),0,None,LpContinuous)
    coeffs = range(1000)
    expr = LpAffineExpression()
    for n in range(10):  #Ten times building an expression of 1000 elements
        print n
        for i in range(1000): # 1000 elements
            expr += coeffs[i] * vars[i]

In my cpython it took 13 sec. Now after adding __iadd__ it takes only 0.4 secs!  

PS: An LpContrains also takes the same advantage as it Inheritance the __iadd__ function from LpAffineExpression